### PR TITLE
Use the setup function from ember-prism

### DIFF
--- a/addon/initializers/showdown-extension.js
+++ b/addon/initializers/showdown-extension.js
@@ -3,6 +3,10 @@
 import showdown from 'showdown';
 import { assert } from '@ember/debug';
 
+import { setup } from 'ember-prism';
+
+setup();
+
 // taken from prismjs, regex to detect newlines in text
 const NEW_LINE_EXP = /\n(?!$)/g;
 

--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ const { join } = require('path');
 module.exports = {
   name: require('./package').name,
 
-  treeForPublic: function() {
+  treeForPublic: function () {
     return new Funnel(join(this.root, 'public'));
   },
 
   included() {
     let app = findHost(this);
-    if(!app.options['ember-prism']) {
+    if (!app.options['ember-prism']) {
       app.options['ember-prism'] = {
         theme: 'okaidia',
 
@@ -21,7 +21,6 @@ module.exports = {
           'apacheconf',
           'bash',
           'css',
-          'handlebars',
           'http',
           'javascript',
           'json',
@@ -32,10 +31,10 @@ module.exports = {
           'typescript',
           'diff',
         ],
-      }
+      };
     }
 
-    this._super.included.apply(this, arguments)
+    this._super.included.apply(this, arguments);
   },
 };
 

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -24,8 +24,8 @@ module('Acceptance | index', function (hooks) {
     assert.dom('pre.language-handlebars code.language-handlebars').isVisible();
     assert
       .dom('pre.language-handlebars code.language-handlebars')
-      .hasText(
-        `<h1>{{@model.title}}</h1> <h2>by {{@model.author}}</h2> <div class="intro"> {{@model.intro}} </div> <hr> <div class="body"> {{@model.body}} </div>`
+      .containsText(
+        `<h1>{{@model.title}}</h1> <h2>by {{@model.author}}</h2> <h3>{{ (count @model.posts) }} # posts</h3> <div class="intro"> {{@model.intro}} </div> <hr> <div class="body"> {{@model.body}} </div>`
       );
   });
 });

--- a/tests/dummy/public/example.md
+++ b/tests/dummy/public/example.md
@@ -18,6 +18,7 @@ Now let's do something a bit more complex
 ```handlebars {data-filename=app/templates/blog-post.hbs}
 <h1>{{@model.title}}</h1>
 <h2>by {{@model.author}}</h2>
+<h3>{{ (count @model.posts) }} # posts</h3>
 
 <div class="intro">
   {{@model.intro}}
@@ -26,6 +27,39 @@ Now let's do something a bit more complex
 <div class="body">
   {{@model.body}}
 </div>
+
+<Nested::Component
+  class="some classes
+    {{if (this.someHelper this.foo 12)
+       "classes when true"
+       "classes when false"
+    }}
+  "
+  @doAction={{fn this.someAction 120}}
+  @argB={{hash
+    foo="string"
+    bar=true
+    baz=120
+    yolo=(array 12 "string" (hash foo=this.something))
+    bax=(fn this.someAction 120)
+  }}
+  {{resize this.handleResize (fn this.idk 2 "str")}}
+>
+  <:block as |foo baz|>
+    {{foo}}
+
+    {{#let foo.bar 12 as |fooBar num|}}
+      <fooBar @num={{num}} @arg={{12}} />
+    {{/let}}
+
+    {{! comment }}
+    {{!-- block }}
+      TODO: Indentation is broken after that
+      comment --}}
+
+    <baz.component />
+  </:block>
+</Nested::Component>
 ```
 
 With some different file types


### PR DESCRIPTION
Looks like it's working, but the theme in the dummy app isn't utilizing all the named tokens:
![image](https://github.com/empress/ember-showdown-prism/assets/199018/8c77320b-5a57-405d-a376-139ab4e1217c)


the `handlebars` language has been _replaced_ by `glimmer` so that all our existing code doesn't need changing.
Also, using the `glimmer` language on code fences shows no changes in the highlighting (proving they're the same parser)


To better show the difference, I added more to the example.md (if you want this removed in the PR, that's fine, too)

**Before**
(handlebars)
![image](https://github.com/empress/ember-showdown-prism/assets/199018/dc5f21f0-553d-4f52-8f06-d1917fbd8845)

**Not yet**
(handlebars + glimmer (they fight each other))
![image](https://github.com/empress/ember-showdown-prism/assets/199018/f570e491-4865-408e-b342-43204a64723a)

**After**
(glimmer only)
![image](https://github.com/empress/ember-showdown-prism/assets/199018/55ca9a41-4fbb-43d5-b179-02789c2ded13)

it's not _perfect_ but it's an improvement over handlebars (which ember doesn't use)



On the ember website: https://guides.emberjs.com/release/in-depth-topics/rendering-values/

![image](https://github.com/empress/ember-showdown-prism/assets/199018/fd946ea3-1151-4a0e-8ae1-94fe43b96cde)

All of this should have some color after updating
