### PR TITLE
add support for data-diff usage in code block

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -86,3 +86,51 @@ pre[class*="language-"].line-numbers > code {
 .line-numbers-rows > a:focus::before {
   color: #fff;
 }
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #c3f590;
+}
+
+code > .token.property,
+code > .token.tag,
+code > .token.constant,
+code > .token.symbol,
+code > .token.deleted {
+  color: #ff6fa3;
+}
+
+code > .diff-insertion {
+  background-color: rgb(93 125 93 / 50%);
+
+  .token.property,
+  .token.tag,
+  .token.constant,
+  .token.symbol,
+  .token.deleted {
+    color: #ff95bb;
+  }
+}
+
+code > .diff-deletion {
+  background-color: rgb(144 84 84 / 70%);
+
+  .token.property,
+  .token.tag,
+  .token.constant,
+  .token.symbol,
+  .token.deleted {
+    color: #ffaac8;
+  }
+}
+
+/* don't include "removed" code when copy-pasting diffs */
+code .diff-operator,
+code .diff-deletion {
+  user-select: none;
+}
+
+code .token.comment {
+  color: #e6e6e6;
+}

--- a/tests/dummy/public/example.md
+++ b/tests/dummy/public/example.md
@@ -43,3 +43,22 @@ export default class BlogPostController extends Controller {
   }
 }
 ```
+
+With a diff: 
+
+```javascript {data-filename="app/router.js" data-diff="+10,-11"}
+import EmberRouter from '@ember/routing/router';
+import config from './config/environment';
+
+const Router = EmberRouter.extend({
+  location: config.locationType,
+  rootURL: config.rootURL
+});
+
+Router.map(function() {
+  this.route('about');
+  this.route('face');
+});
+
+export default Router;
+```


### PR DESCRIPTION
This was accidentally deleted (or rather not ported to the lib) when we migrated the Ember Guides to the new redesign.

I essentially ported to code from https://github.com/ember-learn/guidemaker-ember-template/pull/61/files#diff-4ce1399eddfb8132544fb2b1a80b18832c25d49bedf3e0fafebf6b0ad6281470L97-L115 and the styles from https://github.com/ember-learn/guidemaker-ember-template/pull/61/files#diff-726bb142fb88369eaf8b3721143a35058636de387c65809b9ee15644af4b05e8

If we're happy with this for now we can merge and iterate if we want a better design or whatever later 👍 