### PR TITLE
Fix data-diff first line bug

### DIFF
--- a/addon/initializers/showdown-extension.js
+++ b/addon/initializers/showdown-extension.js
@@ -111,7 +111,6 @@ export function initialize(/* application */) {
           codeblock = `<div class="filename ${language}"><div class="ribbon"></div><span>${attributes['data-filename'] || ''}</span>${codeblock}</div>`;
         }
       } else {
-        // (bug?) This clause may never be reached as the assert above fires in this case?
         codeblock = diffInfo(diffInfoArgs, codeblock);
         codeblock = `<pre class="language-none line-numbers"><code class="language-none">${codeblock}${lineNumbersHTML}</code></pre>`;
       }

--- a/addon/initializers/showdown-extension.js
+++ b/addon/initializers/showdown-extension.js
@@ -6,6 +6,25 @@ import { assert } from '@ember/debug';
 // taken from prismjs, regex to detect newlines in text
 const NEW_LINE_EXP = /\n(?!$)/g;
 
+function diffInfo(args, codeblock) {
+  if (args) {
+    let lines = codeblock.split('\n');
+
+    args.forEach(pD => {
+      let operator = pD[0];
+      let lineNo = +(pD.replace(operator, ''));
+      let text = lines[lineNo - 1];
+      if (operator === '+') {
+        lines[lineNo - 1] = `<span class="diff-insertion"><span class="diff-operator">+</span>${text}</span>`;
+      } else {
+        lines[lineNo - 1] = `<span class="diff-deletion"><span class="diff-operator">-</span>${text}</span>`;
+      }
+    });
+    codeblock = lines.join('\n');
+  }
+  return codeblock;
+}
+
 function getLineNumbersHTML(index, codeblock) {
   let match = codeblock.match(NEW_LINE_EXP);
   let linesNum = match ? match.length + 1 : 1;
@@ -79,6 +98,7 @@ export function initialize(/* application */) {
         codeblock = codeblock.replace(/¨T/g, '¨');
 
         let highlightedCodeBlock = Prism.highlight(codeblock, Prism.languages[language], language) + end;
+        highlightedCodeBlock = diffInfo(attributes['data-diff']?.split(','), highlightedCodeBlock);
         codeblock = `<pre class="language-${language} line-numbers"><code ${language ? `class="${language} language-${language}"` : ''}>${highlightedCodeBlock}${lineNumbersHTML}</code></pre>`;
 
         // Convert to the special characters Showdown uses again
@@ -89,25 +109,8 @@ export function initialize(/* application */) {
           codeblock = `<div class="filename ${language}"><div class="ribbon"></div><span>${attributes['data-filename'] || ''}</span>${codeblock}</div>`;
         }
       } else {
+        codeblock = diffInfo(attributes['data-diff']?.split(','), codeblock);
         codeblock = `<pre class="language-none line-numbers"><code class="language-none">${codeblock}${lineNumbersHTML}</code></pre>`;
-      }
-
-      const diffInfo = attributes['data-diff']?.split(',');
-
-      if (diffInfo) {
-        let lines = codeblock.split('\n');
-
-        diffInfo.forEach(pD => {
-          let operator = pD[0];
-          let lineNo = +(pD.replace(operator, ''));
-          let text = lines[lineNo - 1];
-          if (operator === '+') {
-            lines[lineNo - 1] = `<span class="diff-insertion"><span class="diff-operator">+</span>${text}</span>`;
-          } else {
-            lines[lineNo - 1] = `<span class="diff-deletion"><span class="diff-operator">-</span>${text}</span>`;
-          }
-        });
-        codeblock = lines.join('\n');
       }
 
       codeblock = showdown.subParser('hashBlock')(codeblock, options, globals);

--- a/tests/dummy/public/example.md
+++ b/tests/dummy/public/example.md
@@ -62,3 +62,22 @@ Router.map(function() {
 
 export default Router;
 ```
+
+With a diff on the first line: 
+
+```javascript {data-filename="app/router.js" data-diff="-1,+2"}
+import EmberRouter from '@ember/routing/router';
+import EmberRouter from '@embroider/router';
+import config from './config/environment';
+
+const Router = EmberRouter.extend({
+  location: config.locationType,
+  rootURL: config.rootURL
+});
+
+Router.map(function() {
+  this.route('about');
+});
+
+export default Router;
+```


### PR DESCRIPTION
Fix #56

- diff symbol renders now inside the code block for the first line
- added example for diff on the first line
- tests desperately needed

I am happy with this so far, awaiting comments.