### PR TITLE
add json5, line-numbers, and normalize-whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
           'http',
           'javascript',
           'json',
+          'json5',
           'markup-templating',
           'ruby',
           'scss',
@@ -31,6 +32,7 @@ module.exports = {
           'typescript',
           'diff',
         ],
+        plugins: ['line-numbers', 'normalize-whitespace']
       };
     }
 


### PR DESCRIPTION
Edit from @mansona : this PR has been simplified to add the required config to prism by default 👍 

~Before this change, if `app.options['ember-prism']` has been initially set up by another add-on, the components this addon wanted to use would be ignored. Now it adds any that aren't already there.~

~If the central idea of the PR, that the set of `ember-prism` components should be additive between addons, isn't deemed wise, then reject the PR. In the abstract, I can imagine a component using `ember-showdown-prism` that wants to narrow the range of prism components from 14 to perhaps two or three to keep the runtime size down. With this PR, they would no longer be able to do so. In practice, I doubt that's likely to be a serious concern, but I leave that to the maintainers to decide. They may know of cases where it applies.~

~The original impetus for this fix was that the `typescript` component had been added here and was being ignored when providing typescript examples in the guides. (We also wanted to add json5 examples.) As it turns out, the add-on that was setting a list that pre-empted this one was `guidemaker` itself. That leaves an open question whether `typescript` and `json5` belong in this list or that one.~

~Since typescript is now more central to Ember work in general, I think the typescript component, at least, probably belongs in the base list for this add-on next to javascript. json5 might be more debatable. It's definitely slated for use in the Typescript portion of the guides. We can pull json5 from the PR and move it to the list in guidemaker if desired. If this PR is accepted, guidemaker could either specify precisely what components the guides use or trim its list to things it wants to add. (I suspect they both have the same maintainer. Right, Chris? ;) However you want to architect it.)~

